### PR TITLE
Generalise support for loading bam/cram

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -708,6 +708,9 @@ string &FlankSeq(READ* read, int side) {
 
 void IO::initializeBam() {
     fp_in = hts_open(input_bam.c_str(), "r"); //open bam file
+    if (!reference.empty()) {
+        hts_set_opt(fp_in, CRAM_OPT_REFERENCE, reference.c_str());
+    }
     bamHdr = sam_hdr_read(fp_in); //read header
     idx = sam_index_load(fp_in, input_bam.c_str()); //samtools will implicitly search for the appropriate header if given the filename
     for (int i = 0; i < bamHdr->n_targets; ++i) {

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -707,10 +707,9 @@ string &FlankSeq(READ* read, int side) {
 }
 
 void IO::initializeBam() {
-  fp_in = hts_open(input_bam.c_str(), "r"); //open bam file
+    fp_in = hts_open(input_bam.c_str(), "r"); //open bam file
     bamHdr = sam_hdr_read(fp_in); //read header
-    bai = input_bam + ".bai";
-    idx = sam_index_load(fp_in, bai.c_str());
+    idx = sam_index_load(fp_in, input_bam.c_str()); //samtools will implicitly search for the appropriate header if given the filename
     for (int i = 0; i < bamHdr->n_targets; ++i) {
       chromosomeNames.push_back(bamHdr->target_name[i]);
       chromosomeLengths.push_back(bamHdr->target_len[i]);      

--- a/src/io.h
+++ b/src/io.h
@@ -328,6 +328,7 @@ public:
     string region_and_motifs;
     string input_fasta;
     string input_bam;
+    string reference;
     string vntr_bed;
     string motif_csv;
     string out_vcf;
@@ -359,6 +360,7 @@ public:
       version = "2.1.4";
         region_and_motifs = "";
         input_bam = "";
+        reference = "";
         vntr_bed = "";
         motif_csv = "";
         out_vcf = "";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -693,10 +693,10 @@ int main (int argc, char **argv)
             procInfo[i].opt = &opt;
             procInfo[i].io = new IO;
             procInfo[i].io->input_bam = io.input_bam;
+	    procInfo[i].io->reference = io.reference;
 	    procInfo[i].io->initializeBam();
 	    procInfo[i].io->chromosomeNames = io.chromosomeNames;
             procInfo[i].io->ioLock = &ioLock;
-            procInfo[i].io->idx = io.idx;
             procInfo[i].io->numProcessed = &num_processed;
 	    procInfo[i].io->thread = i;
             procInfo[i].mtx = &mtx;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -353,6 +353,7 @@ int main (int argc, char **argv)
         {"accuracy"        ,required_argument,       0, 'a'},
         {"phase_flank"     ,required_argument,       0, 'p'},
         {"download_db"     ,required_argument,       0, 'm'},
+	{"reference"       ,required_argument,       0, 'R'},
         // {"input",           required_argument,       0, 'i'},
         // {"motif",           required_argument,       0, 'm'},
 
@@ -360,7 +361,7 @@ int main (int argc, char **argv)
     };
     /* getopt_long stores the option index here. */
     int option_index = 0;
-    while ((c = getopt_long (argc, argv, "Sb:r:a:o:C:s:t:f:d:c:x:v:m:p:hL:", long_options, &option_index)) != -1)
+    while ((c = getopt_long (argc, argv, "Sb:r:a:o:C:s:t:f:d:c:x:v:m:R:p:hL:", long_options, &option_index)) != -1)
     {
         switch (c)
         {
@@ -388,7 +389,10 @@ int main (int argc, char **argv)
                 fprintf (stderr, "option --bam with `%s'\n", optarg);
 		io.input_bam = optarg;
                 break;
-
+	    case 'R':
+                fprintf (stderr, "option --reference with `%s'\n", optarg);
+                io.reference = optarg;
+                break;
             case 'v':
                 fprintf (stderr, "option --vntr with `%s'\n", optarg);
                 io.vntr_bed = optarg;


### PR DESCRIPTION
This adds (loosely tested) support for cram files, which just requires passing a reference argument all the way through to a `hts_set_opt` call after opening the bam file. This also removes assuming the index is always ".bai", as bam files could also have a ".csi" index. `sam_index_load` anyway will search for valid index extensions, so this leaves the hard work to htslib.

There was some issues with multithreaded loading of the cram, but that appears resolved in some light testing.
